### PR TITLE
Update BlockChatBox.java

### DIFF
--- a/src/main/java/pl/asie/computronics/block/BlockChatBox.java
+++ b/src/main/java/pl/asie/computronics/block/BlockChatBox.java
@@ -34,6 +34,11 @@ public class BlockChatBox extends BlockMachineSidedIcon {
 	public int getRenderColor(int meta) {
 		return meta >= 8 ? 0xFF60FF : 0xFFFFFF;
 	}
+
+	@Override
+	public int colorMultiplier (IBlockAccess blockAccess, int x, int y, int z) {
+	    return getRenderColor(blockAccess.getBlockMetadata(x, y, z));
+	}
 	
 	@Override
 	public TileEntity createNewTileEntity(World world, int metadata) {


### PR DESCRIPTION
Cheaters never win!
getRenderColor() is only used by the item renderer.  Use colorMultiplier for the block renderer.
